### PR TITLE
Feature/live queue fs update

### DIFF
--- a/src/controls.rs
+++ b/src/controls.rs
@@ -49,7 +49,7 @@ fn load_song(model: &mut Model) -> Result<()> {
     Ok(())
 }
 
-fn load_and_play(model: &mut Model) -> Result<()> {
+pub fn load_and_play(model: &mut Model) -> Result<()> {
     load_song(model)?;
     model.audio.sink.play(); // because sink.clear() pauses
     Ok(())

--- a/src/fwatcher.rs
+++ b/src/fwatcher.rs
@@ -1,0 +1,51 @@
+use crate::{
+    Message,
+    queue::{Song, SongQueue},
+};
+use log::debug;
+use std::thread;
+use std::{collections::HashMap, path::PathBuf};
+use std::{sync::mpsc::Sender, time::Duration};
+
+pub fn scanner(path_str: &String, tx: Sender<Message>, known_songs: Vec<Song>) {
+    let mut known_map: HashMap<PathBuf, Song> = known_songs
+        .into_iter()
+        .map(|s| (s.path.clone(), s))
+        .collect();
+
+    let path = PathBuf::from(path_str);
+    thread::spawn(move || {
+        loop {
+            let curr_scanned_songs = match SongQueue::load_songs_from_path(path.clone()) {
+                Ok(songs) => songs,
+                Err(err) => {
+                    debug!("Failed to scan the {} with error {}", path.display(), err);
+                    Vec::new()
+                }
+            };
+
+            let mut new_songs = Vec::new();
+
+            for song in curr_scanned_songs {
+                match known_map.get(&song.path) {
+                    None => {
+                        new_songs.push(song.clone());
+                        known_map.insert(song.path.clone(), song);
+                    }
+                    Some(old_song) => {
+                        if old_song != &song {
+                            known_map.insert(song.path.clone(), song);
+                        }
+                    }
+                }
+            }
+            if !new_songs.is_empty()
+                && let Err(err) = tx.send(Message::LiveAddNewSongs(new_songs))
+            {
+                debug!("LiveAddNewSongs send failed with {}", err);
+            }
+
+            thread::sleep(Duration::from_secs(3));
+        }
+    });
+}

--- a/src/fwatcher.rs
+++ b/src/fwatcher.rs
@@ -3,9 +3,13 @@ use crate::{
     queue::{Song, SongQueue},
 };
 use log::debug;
-use std::thread;
-use std::{collections::HashMap, path::PathBuf};
-use std::{sync::mpsc::Sender, time::Duration};
+use std::{
+    collections::{HashMap, HashSet},
+    path::PathBuf,
+    sync::mpsc::Sender,
+    thread,
+    time::Duration,
+};
 
 pub fn scanner(path_str: &String, tx: Sender<Message>, known_songs: Vec<Song>) {
     let mut known_map: HashMap<PathBuf, Song> = known_songs
@@ -16,6 +20,8 @@ pub fn scanner(path_str: &String, tx: Sender<Message>, known_songs: Vec<Song>) {
     let path = PathBuf::from(path_str);
     thread::spawn(move || {
         loop {
+            let mut known_paths_set: HashSet<PathBuf> = known_map.keys().cloned().collect();
+
             let curr_scanned_songs = match SongQueue::load_songs_from_path(path.clone()) {
                 Ok(songs) => songs,
                 Err(err) => {
@@ -24,7 +30,23 @@ pub fn scanner(path_str: &String, tx: Sender<Message>, known_songs: Vec<Song>) {
                 }
             };
 
-            let mut new_songs = Vec::new();
+            let curr_scanned_songs_set: HashSet<PathBuf> = curr_scanned_songs
+                .iter()
+                .map(|song| song.path.clone())
+                .collect();
+
+            let removed_paths: Vec<PathBuf> = known_paths_set
+                .extract_if(|song_path| !curr_scanned_songs_set.contains(song_path))
+                .collect();
+
+            let mut new_songs: Vec<Song> = Vec::new();
+            let mut removed_songs: Vec<Song> = Vec::new();
+
+            for removed_path in removed_paths {
+                if let Some(song) = known_map.remove(&removed_path) {
+                    removed_songs.push(song);
+                }
+            }
 
             for song in curr_scanned_songs {
                 match known_map.get(&song.path) {
@@ -39,10 +61,17 @@ pub fn scanner(path_str: &String, tx: Sender<Message>, known_songs: Vec<Song>) {
                     }
                 }
             }
+
             if !new_songs.is_empty()
                 && let Err(err) = tx.send(Message::LiveAddNewSongs(new_songs))
             {
                 debug!("LiveAddNewSongs send failed with {}", err);
+            }
+
+            if !removed_songs.is_empty()
+                && let Err(err) = tx.send(Message::LiveRemoveSongs(removed_songs))
+            {
+                debug!("LiveRemoveSongs send failed with {}", err);
             }
 
             thread::sleep(Duration::from_secs(3));

--- a/src/main.rs
+++ b/src/main.rs
@@ -518,15 +518,18 @@ fn update(model: &mut Model, msg: Message) -> Option<Message> {
 
                 if model.queue.is_empty() {
                     model.app_state = AppState::Init;
-                } else if was_playing {
-                    if let Err(e) = controls::play(model) {
-                        error!("Failed to switch playback after live removal: {e}");
-                    }
-                } else if let Err(e) = controls::load_and_not_play(model) {
-                    error!("Failed to preload after live removal: {e}");
+                    return None;
+                }
+                let result = if was_playing {
+                    controls::load_and_play(model)
+                } else {
+                    controls::load_and_not_play(model)
+                };
+
+                if let Err(e) = result {
+                    error!("Failed to update playback after live removal of songs with: {e}");
                 }
             }
-
             None
         }
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -313,10 +313,13 @@ fn handle_hotkey(keycode: event::KeyCode) -> Option<Message> {
 // this is where state gets updated
 // when adding new state transitions, consider adding tests to solidify them
 fn update(model: &mut Model, msg: Message) -> Option<Message> {
-    debug!(
-        "Current playback state [{:?}], popup [{:?}] <- Message [{:?}]",
-        model.app_state, model.popup, msg
-    );
+    let should_debug = !matches!(&msg, Message::Tick);
+    if should_debug {
+        debug!(
+            "Current playback state [{:?}], popup [{:?}] <- Message [{:?}]",
+            model.app_state, model.popup, msg
+        );
+    }
     let ret = match msg {
         Message::TogglePlay => {
             if model.app_state == AppState::Player(PlayerState::Playing) {
@@ -506,14 +509,33 @@ fn update(model: &mut Model, msg: Message) -> Option<Message> {
             None
         }
         Message::LiveRemoveSongs(removed_songs) => {
-            model.queue.remove_songs(removed_songs);
+            let removed_current_flag = model.queue.remove_songs(removed_songs);
+
+            if removed_current_flag {
+                let was_playing = model.app_state == AppState::Player(PlayerState::Playing);
+
+                model.audio.sink.stop();
+
+                if model.queue.is_empty() {
+                    model.app_state = AppState::Init;
+                } else if was_playing {
+                    if let Err(e) = controls::play(model) {
+                        error!("Failed to switch playback after live removal: {e}");
+                    }
+                } else if let Err(e) = controls::load_and_not_play(model) {
+                    error!("Failed to preload after live removal: {e}");
+                }
+            }
+
             None
         }
     };
-    debug!(
-        "Updated state [{:?}], popup [{:?}], Message [{:?}]",
-        model.app_state, model.popup, ret
-    );
+    if should_debug {
+        debug!(
+            "Updated state [{:?}], popup [{:?}], Message [{:?}]",
+            model.app_state, model.popup, ret
+        );
+    }
     ret
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -189,6 +189,7 @@ enum Message {
     JumpTo(u8),
     Tick,
     LiveAddNewSongs(Vec<Song>),
+    LiveRemoveSongs(Vec<Song>),
 }
 
 fn main() -> Result<()> {
@@ -502,6 +503,10 @@ fn update(model: &mut Model, msg: Message) -> Option<Message> {
         }
         Message::LiveAddNewSongs(new_songs) => {
             model.queue.add_new_songs(new_songs);
+            None
+        }
+        Message::LiveRemoveSongs(removed_songs) => {
+            model.queue.remove_songs(removed_songs);
             None
         }
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod controls;
 mod db;
+mod fwatcher;
 mod logging;
 mod queue;
 mod tui;
@@ -8,7 +9,7 @@ mod utils;
 use color_eyre::{Result, eyre::WrapErr};
 use db::DB;
 use log::{debug, error, warn};
-use queue::SongQueue;
+use queue::{Song, SongQueue};
 use ratatui::crossterm::event::{self, KeyModifiers};
 use ratatui::widgets::TableState;
 use rodio::{OutputStream, Sink};
@@ -43,6 +44,7 @@ impl Model {
             // If unsuccessful, terminate app with error.
             let q = SongQueue::open_path(&args[1]).wrap_err("Error loading songs")?;
             debug!("Successfully loaded songs from {}", args[1]);
+            fwatcher::scanner(&args[1], tx.clone(), q.queue.clone());
             // reset everything except volume level
             let vol = saved_state.volume;
             saved_state = SavedState::default();
@@ -64,7 +66,7 @@ impl Model {
                 _stream: stream, // it's unused, but we can't have it dropped
                 sink,
             },
-            queue: queue,
+            queue,
             channel: Channel { rx, tx },
             db,
             safe_exit_expires_at: None,
@@ -186,6 +188,7 @@ enum Message {
     PlayFromSearch(usize),
     JumpTo(u8),
     Tick,
+    LiveAddNewSongs(Vec<Song>),
 }
 
 fn main() -> Result<()> {
@@ -490,11 +493,15 @@ fn update(model: &mut Model, msg: Message) -> Option<Message> {
             None
         }
         Message::Tick => {
-            if let Some(expires_at) = &model.safe_exit_expires_at {
-                if Instant::now() > *expires_at {
-                    model.safe_exit_expires_at = None;
-                }
+            if let Some(expires_at) = &model.safe_exit_expires_at
+                && Instant::now() > *expires_at
+            {
+                model.safe_exit_expires_at = None;
             }
+            None
+        }
+        Message::LiveAddNewSongs(new_songs) => {
+            model.queue.add_new_songs(new_songs);
             None
         }
     };

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -7,18 +7,18 @@ use std::fs::{self, metadata};
 use std::path::PathBuf;
 
 pub struct SongQueue {
-    queue: Vec<Song>,
+    pub queue: Vec<Song>,
     current_idx: usize,
     filtered_indices: Option<Vec<usize>>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Song {
     pub path: PathBuf,
     pub metadata: Option<Metadata>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Metadata {
     pub title: String,
     pub artist: String,
@@ -121,6 +121,13 @@ impl SongQueue {
         }
     }
 
+    pub fn add_new_songs(&mut self, new_songs: Vec<Song>) {
+        let new_song_count = new_songs.len();
+        self.queue.extend(new_songs);
+
+        debug!("Added {} songs to the queue", new_song_count);
+    }
+
     // When no queue is saved persistently to DB, dutar will scan default Music dir
     // and use that as a queue.
     // It's okay for this function to return empty queue.
@@ -176,7 +183,7 @@ impl SongQueue {
             .collect();
 
         Self {
-            queue: queue,
+            queue,
             current_idx: 0,
             filtered_indices: None,
         }
@@ -196,7 +203,7 @@ impl SongQueue {
         })
     }
 
-    fn load_songs_from_path(path: PathBuf) -> Result<Vec<Song>> {
+    pub fn load_songs_from_path(path: PathBuf) -> Result<Vec<Song>> {
         if !path.exists() {
             return Err(eyre!("Path does not exist: {}", path.display()));
         }
@@ -231,7 +238,7 @@ impl SongQueue {
                     {
                         songs.push(Song {
                             metadata: extract_metadata(&path),
-                            path: path,
+                            path,
                         });
                     }
                 }

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -3,7 +3,7 @@ use color_eyre::{Result, eyre::WrapErr, eyre::eyre};
 use dirs::{audio_dir, home_dir};
 use infer::get_from_path;
 use log::{debug, error, info};
-use std::fs::{self, metadata};
+use std::fs;
 use std::path::PathBuf;
 
 pub struct SongQueue {
@@ -112,13 +112,26 @@ impl SongQueue {
 
     pub fn remove_current_song(&mut self) {
         if self.current_idx < self.queue.len() {
-            self.queue.remove(self.current_idx);
+            let removed = self.queue.remove(self.current_idx);
             if self.queue.is_empty() {
                 self.current_idx = 0;
             } else {
                 self.current_idx %= self.queue.len();
             }
+            let title = if let Some(metadata) = &removed.metadata {
+                metadata.title.as_str()
+            } else {
+                "Unknown"
+            };
+
+            debug!("Removed song [{}] from queue", title);
         }
+    }
+
+    pub fn remove_songs(&mut self, removed_songs: Vec<Song>) {
+        let removed_songs_count = removed_songs.len();
+        self.queue.retain(|song| !removed_songs.contains(song));
+        debug!("Removed {} songs from the queue", removed_songs_count);
     }
 
     pub fn add_new_songs(&mut self, new_songs: Vec<Song>) {

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -128,10 +128,28 @@ impl SongQueue {
         }
     }
 
-    pub fn remove_songs(&mut self, removed_songs: Vec<Song>) {
+    // returns a flag signaling that the currently selected song was removed
+    pub fn remove_songs(&mut self, removed_songs: Vec<Song>) -> bool {
         let removed_songs_count = removed_songs.len();
+
+        // song can be selected, but not playing
+        let removed_current_song = if let Some(curr_selected_song) = self.get_current_song() {
+            removed_songs.contains(curr_selected_song)
+        } else {
+            false
+        };
+
         self.queue.retain(|song| !removed_songs.contains(song));
+
+        if self.queue.is_empty() {
+            self.current_idx = 0
+        } else {
+            self.current_idx %= self.queue.len();
+        }
+
         debug!("Removed {} songs from the queue", removed_songs_count);
+
+        removed_current_song
     }
 
     pub fn add_new_songs(&mut self, new_songs: Vec<Song>) {


### PR DESCRIPTION
Currently we can `remove_current_song` if some Error happens, but if the user adds/deletes songs to the directory provided, that is not reflected in the queue. I propose that we have a watcher that every 3 seconds would go through the fs and see if there are any changes. 

For the case when the currently playing song is deleted, `dutar` pauses. 